### PR TITLE
Exit "gracefully" if shader fails to compile

### DIFF
--- a/src/GLSL.cpp
+++ b/src/GLSL.cpp
@@ -118,7 +118,7 @@ void checkVersion()
 	if (major < 2)
 	{
 		printf("This shader example will not work due to the installed Opengl version, which is %d.%d.\n", major, minor);
-		exit(0);
+		exit(1);
 	}
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -199,6 +199,11 @@ public:
 		prog = make_shared<Program>();
 		prog->setVerbose(true);
 		prog->setShaderNames(resourceDirectory + "/simple_vert.glsl", resourceDirectory + "/simple_frag.glsl");
+		if (! prog->init())
+		{
+			std::cerr << "One or more shaders failed to compile... exiting!" << std::endl;
+			exit(1);
+		}
 		prog->init();
 		prog->addUniform("P");
 		prog->addUniform("MV");


### PR DESCRIPTION
Typically if the shader fails to compile, nothing will show up on the screen and stdout will be flooded with "glUseProgram() failed with invalid_argument". This makes it difficult to see what the actual error was.